### PR TITLE
Removes reference to a non-existent custom crosstool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ You will need:
     specify any exclusive option, except that it requires Linux
     (either container-based or legacy).
   * The `.bazelrc`.
-  * Everything under `tools/`, that includes the custom crosstool and
-    the sha256 fingerprint for Bazel's installer.
+  * Everything under `tools/`, that includes the sha256 fingerprint for Bazel's
+    installer.
   * A (possibly empty) `WORKSPACE` file. See below.
   * Your own `script` section in the `.travis.yml` config file.
 


### PR DESCRIPTION
No crosstool comes with the repo, so remove the README.md reference to it.
